### PR TITLE
Remove pre-install dependency on Cement

### DIFF
--- a/hydra/core/version.py
+++ b/hydra/core/version.py
@@ -1,7 +1,91 @@
+# Copyright (c) Django Software Foundation and individual contributors.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    1. Redistributions of source code must retain the above copyright notice,
+#       this list of conditions and the following disclaimer.
+#
+#    2. Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+#    3. Neither the name of Django nor the names of its contributors may be
+#       used to endorse or promote products derived from this software without
+#       specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
 
-from cement.utils.version import get_version as cement_get_version
+# The following code was copied from the Django project, and only lightly
+# modified.  Please adhere to the above copyright and license for the code
+# in this file.
+
+# Note: Nothing is covered here because this file is imported before nose and
+# coverage take over.. and so its a false positive that nothing is covered.
+
+import datetime  # pragma: nocover
+import os  # pragma: nocover
+import subprocess  # pragma: nocover
 
 VERSION = (0, 0, 3, 'beta', 1)
 
-def get_version(version=VERSION):
-    return cement_get_version(version)
+
+def get_version(version=VERSION):  # pragma: nocover
+    """Returns a PEP 386-compliant version number from VERSION."""
+    assert len(version) == 5
+    assert version[3] in ('alpha', 'beta', 'rc', 'final')
+
+    # Now build the two parts of the version number:
+    # main = X.Y[.Z]
+    # sub = .devN - for pre-alpha releases
+    #     | {a|b|c}N - for alpha, beta and rc releases
+
+    # We want to explicitly include all three version/release numbers
+    # parts = 2 if version[2] == 0 else 3
+    parts = 3
+    main = '.'.join(str(x) for x in version[:parts])
+
+    sub = ''
+    if version[3] == 'alpha' and version[4] == 0:
+        git_changeset = get_git_changeset()
+        if git_changeset:
+            sub = '.dev%s' % git_changeset
+
+    elif version[3] != 'final':
+        mapping = {'alpha': 'a', 'beta': 'b', 'rc': 'c'}
+        sub = mapping[version[3]] + str(version[4])
+
+    return main + sub
+
+
+def get_git_changeset():  # pragma: nocover
+    """Returns a numeric identifier of the latest git changeset.
+
+    The result is the UTC timestamp of the changeset in YYYYMMDDHHMMSS format.
+    This value isn't guaranteed to be unique, but collisions are very
+    unlikely, so it's sufficient for generating the development version
+    numbers.
+    """
+    repo_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    git_log = subprocess.Popen('git log --pretty=format:%ct --quiet -1 HEAD',
+                               stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                               shell=True, cwd=repo_dir,
+                               universal_newlines=True)
+    timestamp = git_log.communicate()[0]
+    try:
+        timestamp = datetime.datetime.utcfromtimestamp(int(timestamp))
+    except ValueError: 	# pragma: nocover
+        return None  	# pragma: nocover
+    return timestamp.strftime('%Y%m%d%H%M%S')

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     author='Lee Bailey',
     author_email='lbailey@shipchain.io',
     url='https://github.com/shipchain/hydra',
-    license='unlicensed',
+    license='Apache-2.0',
     packages=find_packages(exclude=['ez_setup', 'tests*']),
     package_data={'hydra': ['templates/*']},
     include_package_data=True,


### PR DESCRIPTION
Remove direct dependency on cement prior to install phase in setup.py

The dependency on cement was for get_version functionality.  This logic in cement does not rely on any cement specific logic and was originally copied from Django.  That code has been replicated here to prevent the import of cement prior to its installation.  The Django license text has been included in this file in accordance with the license.

This fixes #2 