### PR TITLE
Pin PyYaml to 3.13 to prevent warning from deprecated load method

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 cement==3.0.0
 jinja2
-pyyaml>=3.13
+pyyaml==3.13
 colorlog
 pyfiglet
 colored


### PR DESCRIPTION
pyyaml recently released version 5.1 which deprecated the base `load` method which cement version 3.0.0 uses. https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation

Since cement is pinned to version 3.0.0 (which uses the old style call to `load`) we should also pin pyyaml to the previous version 3.13