### PR TITLE
Add quick-start guide to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,12 @@ Note: Replace network-name with your chosen network (e.g. shipchain-testnet-alph
 `hydra client join-network -n network-name`
 2. Configure client
 `hydra client configure -n network-name`
-3. Run node
+3. Start node and begin syncing with network - this will take a while
 `cd network-name && ./start_blockchain.sh`
 
 Your node is sync'd to the network when `curl localhost:46657/status` returns `sync_info.catching_up: false`
 
+Shipchain validator node commands can be accessed from `~/hydra/network-name/shipchain`
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ $ source env/bin/activate
 
 ### Client controller
 #### Configure client
-```
-$ hydra client configure *network name*
+
+`$ hydra client configure *network name*`
 ```
 Takes network name as a parameter
 #### Join a network

--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ Note: Replace network-name with your chosen network (e.g. shipchain-testnet-alph
 2. Configure client
 `hydra client configure -n network-name`
 3. Run node
-`cd network-name && ./shipchain run`
+`cd network-name && ./start_blockchain.sh`
+
+Your node is sync'd to the network when `curl localhost:46657/status` returns `sync_info.catching_up: false`
 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -29,19 +29,21 @@ Your node is sync'd to the network when `curl localhost:46657/status` returns `s
 
 Shipchain validator node commands can be accessed from `~/hydra/network-name/shipchain`
 
-## Installation
 
+## General Installation and Development Guidelines
+
+### Installation
 ```
 $ pip install -r requirements.txt
 
 $ pip install setup.py
 ```
 
-## Development
+### Development
 
 This project includes a number of helpers in the `Makefile` to streamline common development tasks.
 
-### Environment Setup
+#### Environment Setup
 
 The following demonstrates setting up and working with a development environment:
 
@@ -64,7 +66,7 @@ $ make test
 ```
 
 
-### Releasing to PyPi
+#### Releasing to PyPi
 
 Before releasing to PyPi, you must configure your login credentials:
 
@@ -84,9 +86,9 @@ $ make dist
 $ make dist-upload
 ```
 
-## Deployments
+### Deployments
 
-### Docker
+#### Docker
 
 Included is a basic `Dockerfile` for building and distributing `ShipChain Network Hydra Manager`,
 and can be built with the included `make` helper:

--- a/README.md
+++ b/README.md
@@ -8,39 +8,52 @@
 
 # Hydra manages many heads of networks
 
+## Get-started guide
+
+### Install
+``` 
+make virtualenv
+source env/bin/activate
+```
+### Configure client and run node
+
+Note: Replace network-name with your chosen network (e.g. shipchain-testnet-alpha)
+1. Join a network
+`hydra client join-network -n network-name`
+2. Configure client
+`hydra client configure -n network-name`
+3. Run node
+`cd network-name && ./shipchain run`
+
+
+## Installation
+
+```
+$ pip install -r requirements.txt
+
+$ pip install setup.py
+```
+
 ## Development
 
 This project includes a number of helpers in the `Makefile` to streamline common development tasks.
 
-## Installation
+### Environment Setup
+
+The following demonstrates setting up and working with a development environment:
+
+```
+### create a virtualenv for development
 
 $ make virtualenv
 
 $ source env/bin/activate
 
-## Usage
 
-### Client controller
-#### Configure client
+### run hydra cli application
 
-`$ hydra client configure *network name*`
-```
-Takes network name as a parameter
-#### Join a network
-```
-$ hydra client join-network *network name*
-```
-Takes network name as a paramenter (e.g. shipchain-testnet-alpha)
+$ hydra --help
 
-#### Update hydra 
-````
-$ hydra client update
-````
-
-#### 
-```
-$ hydra set-channel
-```
 
 ### run pytest / coverage
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 # Hydra manages many heads of networks
 
-## Get-started guide
+## Quick-start Guide
 
 ### Install
 ``` 

--- a/README.md
+++ b/README.md
@@ -8,34 +8,39 @@
 
 # Hydra manages many heads of networks
 
-## Installation
-
-```
-$ pip install -r requirements.txt
-
-$ pip install setup.py
-```
-
 ## Development
 
 This project includes a number of helpers in the `Makefile` to streamline common development tasks.
 
-### Environment Setup
-
-The following demonstrates setting up and working with a development environment:
-
-```
-### create a virtualenv for development
+## Installation
 
 $ make virtualenv
 
 $ source env/bin/activate
 
+## Usage
 
-### run hydra cli application
+### Client controller
+#### Configure client
+```
+$ hydra client configure *network name*
+```
+Takes network name as a parameter
+#### Join a network
+```
+$ hydra client join-network *network name*
+```
+Takes network name as a paramenter (e.g. shipchain-testnet-alpha)
 
-$ hydra --help
+#### Update hydra 
+````
+$ hydra client update
+````
 
+#### 
+```
+$ hydra set-channel
+```
 
 ### run pytest / coverage
 


### PR DESCRIPTION
Here's a first pass at adding a quick-start guide to the readme.  I'm not knowledgeable enough on the overall project to provide detailed usage guidelines on the whole CLI or validator node setup but this would be a helpful way to get someone started.