### PR TITLE
Add `leave-network` command

### DIFF
--- a/hydra/controllers/client.py
+++ b/hydra/controllers/client.py
@@ -225,10 +225,12 @@ class Client(Controller):  # pylint: disable=too-many-ancestors
             self.app.client.uninstall_systemd(name)
         except HydraError as exc:
             self.app.log.warning(exc)
-            self.app.log.info(f'Service not installed.  Continuing.')
+            self.app.log.info(f'Service not installed.  Attempting to stop executable manually.')
+            self.app.client.find_and_kill_executable(destination)
 
         # Remove network directory
         rmtree(destination)
+        self.app.log.info(f'Removed network directory {destination}')
 
         # Remove .hydra_network if this is the default network
         default_network_file = self.app.utils.path('.hydra_network')
@@ -243,3 +245,6 @@ class Client(Controller):  # pylint: disable=too-many-ancestors
 
             if remove_default_network:
                 os.remove(default_network_file)
+                self.app.log.info(f'Removed default network setting')
+
+        self.app.log.info(f'Successfully left network {name}')

--- a/hydra/controllers/client.py
+++ b/hydra/controllers/client.py
@@ -6,6 +6,8 @@ from cement import Controller, ex
 import requests
 import yaml
 
+from hydra.core.exc import HydraError
+
 YAML_LOAD = yaml.full_load if hasattr(yaml, 'full_load') else yaml.load
 
 
@@ -189,3 +191,55 @@ class Client(Controller):  # pylint: disable=too-many-ancestors
 
         if self.app.pargs.install:
             self.app.client.install_systemd(name, destination, user=self.app.utils.binary_exec('whoami').stdout.strip())
+
+    @ex(
+        arguments=[
+            (
+                    ['-n', '--name'],
+                    {
+                        'help': 'name of network to leave',
+                        'action': 'store',
+                        'dest': 'name'
+                    }
+            ),
+            (
+                    ['-d', '--destination'],
+                    {
+                        'help': 'destination directory',
+                        'action': 'store',
+                        'dest': 'destination'
+                    }
+            ),
+        ]
+    )
+    def leave_network(self):
+        name = self.app.utils.env_or_arg('name', 'HYDRA_NETWORK', or_path='.hydra_network', required=True)
+        destination = self.app.pargs.destination or self.app.utils.path(name)
+
+        # Verify network directory exists before we start removing everything
+        if not os.path.exists(destination):
+            raise HydraError(f'Network directory {destination} does not exist')
+
+        # Stop and remove service before removing network directory
+        try:
+            self.app.client.uninstall_systemd(name)
+        except HydraError as exc:
+            self.app.log.warning(exc)
+            self.app.log.info(f'Service not installed.  Continuing.')
+
+        # Remove network directory
+        rmtree(destination)
+
+        # Remove .hydra_network if this is the default network
+        default_network_file = self.app.utils.path('.hydra_network')
+
+        if os.path.exists(default_network_file):
+            remove_default_network = False
+
+            with open(default_network_file, 'r') as network_file:
+                default_network = network_file.readline().strip()
+                if default_network == name:
+                    remove_default_network = True
+
+            if remove_default_network:
+                os.remove(default_network_file)

--- a/hydra/helpers/client.py
+++ b/hydra/helpers/client.py
@@ -86,7 +86,10 @@ class ClientHelper(HydraHelper):
     def get_pid(self, executable_path):
         self.app.log.info(f'Scanning for running `shipchain` executables')
 
-        pid_list = map(int, subprocess.check_output(['pidof', 'shipchain']).split())
+        try:
+            pid_list = map(int, subprocess.check_output(['pidof', 'shipchain']).split())
+        except subprocess.CalledProcessError:
+            return None
 
         for pid in pid_list:
             try:

--- a/hydra/helpers/client.py
+++ b/hydra/helpers/client.py
@@ -56,6 +56,7 @@ class ClientHelper(HydraHelper):
         self.app.utils.binary_exec('sudo', 'cp', service_name, systemd_service)
         self.app.utils.binary_exec('sudo', 'chown', 'root:root', systemd_service)
         self.app.utils.binary_exec('sudo', 'systemctl', 'daemon-reload')
+        self.app.utils.binary_exec('sudo', 'systemctl', 'enable', service_name)
         self.app.utils.binary_exec('sudo', 'systemctl', 'start', service_name)
 
     def uninstall_systemd(self, name):


### PR DESCRIPTION
As new test networks are released, we need an easy way to leave the previous network.

`hydra client leave-network` will
 - uninstall the systemd service (if installed)
 - stop the running node process (if not stopped via systemctl)
 - remove the network directory
 - cleanup the default network file (if this was the default network)