### PR TITLE
Join Network should run the Configure step by default

### DIFF
--- a/hydra/controllers/client.py
+++ b/hydra/controllers/client.py
@@ -100,6 +100,15 @@ class Client(Controller):  # pylint: disable=too-many-ancestors
                         'dest': 'install'
                     }
             ),
+            (
+                    ['--no-configure'],
+                    {
+                        'help': 'prevent the configuration step from running',
+                        'action': 'store_false',
+                        'dest': 'do_configure',
+                        'default': 'true'
+                    }
+            ),
         ]
     )
     def join_network(self):
@@ -129,6 +138,9 @@ class Client(Controller):  # pylint: disable=too-many-ancestors
 
         self.app.client.bootstrap(
             destination, version=version, destroy=self.app.pargs.destroy)
+
+        if self.app.pargs.do_configure:
+            self.app.client.configure(name, destination, version=self.app.pargs.version or 'latest')
 
         if self.app.pargs.install:
             self.app.client.install_systemd(name, destination, user=self.app.utils.binary_exec('whoami').stdout.strip())

--- a/hydra/helpers/networks.py
+++ b/hydra/helpers/networks.py
@@ -124,6 +124,9 @@ class NetworksHelper(HydraHelper):
                 SubnetId=subnet
             )
         ]
+
+        join_network_arguments = f'--name={stack_name} --set-default --install --no-configure'
+
         instance.UserData = Base64(
             Join(
                 '',
@@ -135,7 +138,7 @@ class NetworksHelper(HydraHelper):
                     'apt remove -y -q python3-yaml\n',
                     'pip3 install cement colorlog\n',
                     f'pip3 install {self.app.config.get("provision", "pip_install") % self.app.config["hydra"]}\n',
-                    f'su -l -c "hydra client join-network --name={stack_name} --set-default --install" ubuntu\n'
+                    f'su -l -c "hydra client join-network {join_network_arguments}" ubuntu\n'
                 ])
         )
         template.add_resource(instance)


### PR DESCRIPTION
Currently if you run `hydra client join-network --install` the systemd service will be created, but will fail due to the absence of the `start_blockchain.sh` script.  The `hydra client configure` step generates the required files needed for the service to start properly.

This change includes the configuration logic as part of `join-network` _unless_ a new `--no-configure` argument is provided, removing a step from the node setup process.

_Note: Network provisioning includes the `--no-configure` parameter to keep the functionality consistent.  When provisioning, the genesis file setup steps are not the same as those in the client configuration._