### PR TITLE
Specify binary version for network

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+networks*
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/config/hydra.yml.example
+++ b/config/hydra.yml.example
@@ -44,3 +44,8 @@ log.colorlog:
 
 ### The maximun number of log files to maintain when rotating
 # max_files: 4
+
+provision:
+
+### The name of the EC2 instance key to be used when creating instances (must be present in ~/.ssh)
+# aws_ec2_key_name: my-ec2-key

--- a/hydra/controllers/client.py
+++ b/hydra/controllers/client.py
@@ -126,10 +126,10 @@ class Client(Controller):  # pylint: disable=too-many-ancestors
             rmtree(destination)
 
         if not self.app.pargs.version:
-            url = f'{self.app.config["hydra"]["channel_url"]}/networks/{name}.json'
+            url = f'{self.app.config["hydra"]["channel_url"]}/networks/{name}/hydra.json'
             try:
                 remote_config = json.loads(requests.get(url).content)
-                version = remote_config['binary_version']
+                version = remote_config['version']
             except json.JSONDecodeError:
                 self.app.log.warning(f'Error getting network version details from {url}, using "latest"')
                 version = "latest"

--- a/hydra/helpers/client.py
+++ b/hydra/helpers/client.py
@@ -68,7 +68,7 @@ class ClientHelper(HydraHelper):
 
         os.chdir(destination)
 
-        self.app.utils.download_release_file('./shipchain', 'shipchain')
+        self.app.utils.download_release_file('./shipchain', 'shipchain', version)
 
         os.chmod('./shipchain', os.stat('./shipchain').st_mode | stat.S_IEXEC)
 

--- a/hydra/main.py
+++ b/hydra/main.py
@@ -105,7 +105,7 @@ def main():
             print('First run: Generating ~/.hydra.yml config...')
             from yaml import dump
             open(app.config_file, 'w+').write(
-                dump({'hydra': CONFIG['hydra']}, indent=4))
+                dump(CONFIG, indent=4, default_flow_style=False))
         try:
             app.run()
 


### PR DESCRIPTION
When testing new loom binaries, one might need to specify a custom version of the binary (not-latest) to be used by nodes when provisioning. This PR adds this functionality.

Also included are various bugfixes to the provisioning flow.