### PR TITLE
Backup/Restore Commands

### DIFF
--- a/hydra/controllers/client.py
+++ b/hydra/controllers/client.py
@@ -917,14 +917,14 @@ class Client(Controller):  # pylint: disable=too-many-ancestors
         ]
 
         self.app.log.info(f'Backing up files to {destination}/{name}')
-        for file in files_to_backup:
-            dest_file = f'{destination}/{name}/{file}'
+        for src_file in files_to_backup:
+            dest_file = f'{destination}/{name}/{src_file}'
             os.makedirs(os.path.dirname(dest_file), exist_ok=True)
 
             if os.path.exists(dest_file) and not force:
                 self.app.log.error(f'{dest_file} already exists, to overwrite rerun command with "-f" ')
             else:
-                copyfile(file, dest_file)
+                copyfile(src_file, dest_file)
                 self.app.log.info(f'{dest_file} backed up.')
 
     @ex(
@@ -971,11 +971,11 @@ class Client(Controller):  # pylint: disable=too-many-ancestors
 
         self.app.log.info(f'Restoring backup from {source}/{name} to {network_folder}')
         for dest_file in files_to_restore:
-            file = f'{source}/{name}/{dest_file}'
-            if not os.path.exists(file):
-                self.app.log.error(f'{file} does not exist, cannot restore.')
+            src_file = f'{source}/{name}/{dest_file}'
+            if not os.path.exists(src_file):
+                self.app.log.error(f'{src_file} does not exist, cannot restore.')
             elif os.path.exists(dest_file) and not force:
                 self.app.log.error(f'{dest_file} already exists, to overwrite rerun command with "-f" ')
             else:
-                copyfile(file, dest_file)
+                copyfile(src_file, dest_file)
                 self.app.log.info(f'{dest_file} restored.')

--- a/hydra/controllers/client.py
+++ b/hydra/controllers/client.py
@@ -938,7 +938,15 @@ class Client(Controller):  # pylint: disable=too-many-ancestors
                 }
             ),
             (
-                ['-s', '--source'],
+                ['-r', '--restore-from'],
+                {
+                    'help': 'name of network to restore from',
+                    'action': 'store',
+                    'dest': 'from_name'
+                }
+            ),
+            (
+                ['-s', '--source-path'],
                 {
                     'help': 'path to the source backup directory',
                     'default': '~/.hydra',
@@ -958,6 +966,7 @@ class Client(Controller):  # pylint: disable=too-many-ancestors
     )
     def restore(self):
         name = self.app.utils.env_or_arg('name', 'HYDRA_NETWORK', or_path='.hydra_network', required=True)
+        from_name = self.app.pargs.from_name or name
         source = os.path.expanduser(self.app.pargs.source)
         force = self.app.pargs.force
 
@@ -969,9 +978,9 @@ class Client(Controller):  # pylint: disable=too-many-ancestors
             'chaindata/config/priv_validator.json',
         ]
 
-        self.app.log.info(f'Restoring backup from {source}/{name} to {network_folder}')
+        self.app.log.info(f'Restoring backup from {source}/{from_name} to {network_folder}')
         for dest_file in files_to_restore:
-            src_file = f'{source}/{name}/{dest_file}'
+            src_file = f'{source}/{from_name}/{dest_file}'
             if not os.path.exists(src_file):
                 self.app.log.error(f'{src_file} does not exist, cannot restore.')
             elif os.path.exists(dest_file) and not force:

--- a/hydra/helpers/client.py
+++ b/hydra/helpers/client.py
@@ -91,6 +91,39 @@ class ClientHelper(HydraHelper):
         else:
             self.app.log.info(f'No matching executable running.  Continuing.')
 
+    def stop_service(self, name, destination):
+        service_name = f'{name}.service'
+        systemd_service = f'/etc/systemd/system/{service_name}'
+
+        if os.path.exists(systemd_service):
+            command = ['sudo', 'systemctl', 'stop', name]
+            self.app.log.info(' '.join(command))
+            self.app.utils.binary_exec(*command)
+
+            time.sleep(1)
+
+            command = ['sudo', 'systemctl', 'kill', name]
+            self.app.log.info(' '.join(command))
+            self.app.utils.binary_exec(*command)
+        else:
+            self.app.log.info(f'Service not installed.  Attempting to stop executable.')
+            self.app.client.find_and_kill_executable(destination)
+
+    def start_service(self, name):
+        service_name = f'{name}.service'
+        systemd_service = f'/etc/systemd/system/{service_name}'
+
+        command = ['sudo', 'systemctl', 'start', name]
+        self.app.log.info(' '.join(command))
+        self.app.utils.binary_exec(*command)
+
+        if os.path.exists(systemd_service):
+            command = ['sudo', 'systemctl', 'start', name]
+            self.app.log.info(' '.join(command))
+            self.app.utils.binary_exec(*command)
+        else:
+            self.app.log.warning(f'Service not installed.  You will need to restart your node manually.')
+
     def get_pid(self, executable_path):
         self.app.log.info(f'Scanning for running `shipchain` executables')
 

--- a/hydra/helpers/client.py
+++ b/hydra/helpers/client.py
@@ -113,10 +113,6 @@ class ClientHelper(HydraHelper):
         service_name = f'{name}.service'
         systemd_service = f'/etc/systemd/system/{service_name}'
 
-        command = ['sudo', 'systemctl', 'start', name]
-        self.app.log.info(' '.join(command))
-        self.app.utils.binary_exec(*command)
-
         if os.path.exists(systemd_service):
             command = ['sudo', 'systemctl', 'start', name]
             self.app.log.info(' '.join(command))


### PR DESCRIPTION
This PR adds `hydra client backup` and `hydra client restore`, two commands designed for validator sysadmins, to ensure that they can easily take backups of their validator's private keys.

The default backup directory is in the user's home directory (`~/.hydra/{network-name}/`). This command _will not_ overwrite existing data on either the backup or restore step. To force an overwrite, `-f` can be passed to the command. **TAKE GREAT CARE** when using the restore command.